### PR TITLE
Add Vision / VLM models to environments and GRPO trainer

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,8 @@
+La génération se fait avec OpenAI dans les envs qui est déjà robuste aux images dans prompt : ok pour ça
+
+Il faut juste check dans le trainer je pense
+
+Il faut que dans l'input il y ait images en optionnel qui sera en input de la processing classe ?
+
+
+Est-ce que dans _prepare_inputs il faut gérer les images ? ou seulement dans _get_per_token_logps ?

--- a/notes.md
+++ b/notes.md
@@ -1,8 +1,0 @@
-La génération se fait avec OpenAI dans les envs qui est déjà robuste aux images dans prompt : ok pour ça
-
-Il faut juste check dans le trainer je pense
-
-Il faut que dans l'input il y ait images en optionnel qui sera en input de la processing classe ?
-
-
-Est-ce que dans _prepare_inputs il faut gérer les images ? ou seulement dans _get_per_token_logps ?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
     "rich",
     "textual",
     "openai-agents>=0.0.7",
-    "pillow>=10.0.0"
+    "pillow>=10.0.0",
+    "transformers"
 ]
 
 [project.optional-dependencies]
@@ -45,7 +46,6 @@ all = [
     "pytest-cov>=4.0.0",
     "requests",
     "torch>=2.7.0",
-    "transformers",
     "accelerate>=1.4.0",
     "deepspeed",
     "peft",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "rich",
     "textual",
     "openai-agents>=0.0.7",
+    "pillow>=10.0.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -308,6 +308,8 @@ class TestEnvironmentBase:
         (
             prompt_ids,
             prompt_mask,
+            prompt_image_grid, 
+            prompt_pixel_value,
             completion_ids,
             completion_mask,
             completion_logprobs,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -261,6 +261,8 @@ class TestEnvironmentBase:
         (
             prompt_ids,
             prompt_mask,
+            prompt_image_grid, 
+            prompt_pixel_value,
             completion_ids,
             completion_mask,
             completion_logprobs,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -125,7 +125,6 @@ class Environment(ABC):
             self.logger.warning(
                 "The parser and rubric parser are different. This may cause unexpected behavior."
             )
-
         if self.message_type == "chat":
             if dataset is not None:
                 self.dataset = self.format_dataset(

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -987,7 +987,7 @@ class Environment(ABC):
             prompt_ids=all_prompt_ids,
             prompt_mask=all_prompt_masks,
             image_grid = all_prompt_image_grid,
-            pixel_value= all_prompt_pixel_value,
+            pixel_values= all_prompt_pixel_value,
             completion_ids=all_completion_ids,
             completion_mask=all_completion_masks,
             completion_logprobs=all_completion_logprobs,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -55,14 +55,8 @@ def encode_chat_with_processor(
     Apply chat template and return token IDs, handling both tokenizer and processor.
     Supports base64-encoded images in the conversation.
     """
-    if isinstance(processing_class, PreTrainedTokenizerBase):
-        prompt_ids : List[int] = processing_class.apply_chat_template(
-            conversation=conversation,
-            add_generation_prompt=add_generation_prompt,
-        )
-        return prompt_ids,None,None
 
-    elif isinstance(processing_class, ProcessorMixin):
+    if isinstance(processing_class, ProcessorMixin):
         prompt_text = processing_class.apply_chat_template(
             conversation=conversation,
             add_generation_prompt=add_generation_prompt,
@@ -85,7 +79,11 @@ def encode_chat_with_processor(
         return inputs["input_ids"][0].tolist(), inputs["image_grid_thw"][0].tolist(), inputs["pixel_values"].tolist()
 
     else:
-        raise TypeError(f"Unsupported processing_class: {type(processing_class)}")
+        prompt_ids : List[int] = processing_class.apply_chat_template(
+            conversation=conversation,
+            add_generation_prompt=add_generation_prompt,
+        )
+        return prompt_ids,None,None
     
 class Environment(ABC):
     """

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -9,7 +9,6 @@ from transformers import ProcessorMixin
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-import transformers
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from typing import TYPE_CHECKING, Literal, Union
-from transformers import ProcessorMixin, AutoProcessor, AutoConfig
+from transformers import ProcessorMixin
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -780,16 +780,16 @@ class Environment(ABC):
         # Ici on ajoute les images en kwargs
         
         kwargs = {}
-        has_images = "image" in inputs[0]
-        if has_images:
-            images = [example.get("image") for example in inputs]
-            kwargs = {"images": [[img] for img in images]}
-            if isinstance(prompt, list):
-                for message in prompt:
-                    if isinstance(message, dict) and message.get("role") == "user":
-                        if isinstance(message.get("content"), str):
-                            message["content"] = [{"type": "image"}, {"type": "text", "text": message["content"]}]
-                        break
+        # has_images = "image" in inputs[0]
+        # if has_images:
+        #     images = [example.get("image") for example in inputs]
+        #     kwargs = {"images": [[img] for img in images]}
+        #     if isinstance(prompt, list):
+        #         for message in prompt:
+        #             if isinstance(message, dict) and message.get("role") == "user":
+        #                 if isinstance(message.get("content"), str):
+        #                     message["content"] = [{"type": "image"}, {"type": "text", "text": message["content"]}]
+        #                 break
                         
         prompt_ids: list[int] = processing_class(prompt,**kwargs)
         rollout_consumed = prompt

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -986,8 +986,8 @@ class Environment(ABC):
         return ProcessedOutputs(
             prompt_ids=all_prompt_ids,
             prompt_mask=all_prompt_masks,
-            image_grid = all_prompt_image_grid,
-            pixel_value= all_prompt_pixel_value,
+            image_grid_thw = all_prompt_image_grid,
+            pixel_values= all_prompt_pixel_value,
             completion_ids=all_completion_ids,
             completion_mask=all_completion_masks,
             completion_logprobs=all_completion_logprobs,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -86,7 +86,7 @@ def encode_chat_with_processor(
             return_tensors="pt",
             add_special_tokens=add_special_tokens,
         )
-        return inputs["input_ids"][0].tolist(), inputs["image_grid_thw"][0].tolist(), inputs["pixel_values"][0].tolist()
+        return inputs["input_ids"], inputs["image_grid_thw"], inputs["pixel_values"]
 
     else:
         raise TypeError(f"Unsupported processing_class: {type(processing_class)}")

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Literal, Union, List, Dict
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 import base64
 from io import BytesIO
 from PIL import Image

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -88,7 +88,6 @@ def encode_chat_with_processor(
 def encode_text_with_processor(
     text: str,
     processing_class: Union[PreTrainedTokenizerBase, ProcessorMixin],
-    add_special_tokens: bool = False,
 ) -> tuple[list[int], Any, Any]:
     """
     Encode plain text and return token IDs, handling both tokenizer and processor.
@@ -98,7 +97,6 @@ def encode_text_with_processor(
             text=[text],
             images=None,
             return_tensors="pt",
-            add_special_tokens=add_special_tokens,
         )
         input_ids = inputs["input_ids"][0].tolist()
         image_grid = inputs.get("image_grid_thw", [None])[0].tolist()
@@ -106,7 +104,7 @@ def encode_text_with_processor(
         return input_ids, image_grid, pixel_values
     else:
         prompt_ids: list[int] = processing_class.encode(
-            text, add_special_tokens=add_special_tokens
+            text
         )
         return prompt_ids, None, None
     
@@ -857,9 +855,8 @@ class Environment(ABC):
         assert idx == len(completion), "Completion not fully consumed"
 
         prompt_ids, prompt_image_grid, prompt_pixel_value = encode_text_with_processor(
-            text=prompt,  # The prompt is a string for completion format
+            text=prompt,
             processing_class=processing_class,
-            add_special_tokens=False,
         )
         rollout_consumed = prompt
         prompt_mask: list[int] = [0] * len(prompt_ids)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -86,8 +86,7 @@ def encode_chat_with_processor(
             return_tensors="pt",
             add_special_tokens=add_special_tokens,
         )
-        print("encode_chat_with_processor",inputs["pixel_values"].shape)
-        return inputs["input_ids"], inputs["image_grid_thw"], inputs["pixel_values"]
+        return inputs["input_ids"][0].tolist(), inputs["image_grid_thw"][0].tolist(), inputs["pixel_values"].tolist()
 
     else:
         raise TypeError(f"Unsupported processing_class: {type(processing_class)}")
@@ -529,7 +528,6 @@ class Environment(ABC):
         if isinstance(client, OpenAI):
             client = AsyncOpenAI(api_key=client.api_key, base_url=client.base_url)
 
-        print("inputs",inputs)
         coro = self.a_generate(
             inputs,
             client,
@@ -985,7 +983,6 @@ class Environment(ABC):
             else:
                 all_rewards.append(reward)
                 
-        print("process_env_results_vllm",all_prompt_pixel_value.shape)
         return ProcessedOutputs(
             prompt_ids=all_prompt_ids,
             prompt_mask=all_prompt_masks,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -77,7 +77,7 @@ def encode_chat_with_processor(
         for msg in conversation:
             for c in msg.get("content", []):
                 if c.get("type") == "image_url":
-                    pil_img = _base64_to_pil(c["image_url"])
+                    pil_img = _base64_to_pil(c["image_url"]["url"])
                     images.append(pil_img)
 
         inputs = processing_class(
@@ -86,7 +86,7 @@ def encode_chat_with_processor(
             return_tensors="pt",
             add_special_tokens=add_special_tokens,
         )
-        return inputs["input_ids"][0].tolist(), inputs["image_grid"][0].tolist(), inputs["pixel_values"][0].tolist()
+        return inputs["input_ids"][0].tolist(), inputs["image_grid_thw"][0].tolist(), inputs["pixel_values"][0].tolist()
 
     else:
         raise TypeError(f"Unsupported processing_class: {type(processing_class)}")

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -4,11 +4,14 @@ import logging
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from typing import TYPE_CHECKING, Literal, Union
-from transformers import ProcessorMixin
+from typing import TYPE_CHECKING, Literal, Union, List, Dict
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+import base64
+from io import BytesIO
+from PIL import Image
+from transformers import PreTrainedTokenizerBase, ProcessorMixin
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
@@ -28,12 +31,6 @@ from verifiers.types import (
     State,
 )
 from verifiers.utils.message_utils import cleanup_messages, sanitize_tool_calls
-
-import base64
-from io import BytesIO
-from typing import List, Dict, Union
-from PIL import Image
-from transformers import PreTrainedTokenizerBase, ProcessorMixin
 
 if TYPE_CHECKING:
     from transformers.tokenization_utils_base import (  # type: ignore

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -912,8 +912,6 @@ class Environment(ABC):
         all_completion_masks = []
         all_completion_logprobs = []
         all_rewards = []
-        all_images=[]
-        all_answers=[]
         for i, (prompt, completion, state, reward) in enumerate(
             zip(prompts, completions, states, rewards)
         ):

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -918,6 +918,8 @@ class Environment(ABC):
         all_completion_masks = []
         all_completion_logprobs = []
         all_rewards = []
+        all_images=[]
+        all_answers=[]
         for i, (prompt, completion, state, reward) in enumerate(
             zip(prompts, completions, states, rewards)
         ):
@@ -978,6 +980,7 @@ class Environment(ABC):
             all_completion_ids.append(completion_ids)
             all_completion_masks.append(completion_mask)
             all_completion_logprobs.append(completion_logprobs)
+            
             if zero_truncated_completions and is_truncated:
                 all_rewards.append(0)
             else:
@@ -992,7 +995,6 @@ class Environment(ABC):
             completion_mask=all_completion_masks,
             completion_logprobs=all_completion_logprobs,
             rewards=all_rewards,
-            
         )
 
     # alias for process_env_results_vllm

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -86,6 +86,7 @@ def encode_chat_with_processor(
             return_tensors="pt",
             add_special_tokens=add_special_tokens,
         )
+        print("encode_chat_with_processor",inputs["pixel_values"].shape)
         return inputs["input_ids"], inputs["image_grid_thw"], inputs["pixel_values"]
 
     else:
@@ -983,6 +984,8 @@ class Environment(ABC):
                 all_rewards.append(0)
             else:
                 all_rewards.append(reward)
+                
+        print("process_env_results_vllm",all_prompt_pixel_value.shape)
         return ProcessedOutputs(
             prompt_ids=all_prompt_ids,
             prompt_mask=all_prompt_masks,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -9,7 +9,7 @@ from transformers import ProcessorMixin, AutoProcessor, AutoConfig
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-
+import transformers
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
@@ -225,6 +225,7 @@ class Environment(ABC):
         ):
             sampling_args.pop("max_completion_tokens")
         clean_sampling_args = {k: v for k, v in sampling_args.items() if v is not None}
+
         try:
             if message_type == "chat":
                 assert isinstance(prompt, list)
@@ -471,6 +472,8 @@ class Environment(ABC):
     ) -> GenerateOutputs:
         if isinstance(client, OpenAI):
             client = AsyncOpenAI(api_key=client.api_key, base_url=client.base_url)
+
+        print("inputs",inputs)
         coro = self.a_generate(
             inputs,
             client,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -789,7 +789,6 @@ class Environment(ABC):
                 else:
                     completion_turn_mask = [1] * len(completion_turn_ids)
                     
-                # TODO : what about images in turn ? for now we consider we hav'nt
                 completion_turn_logprobs = [0.0] * len(completion_turn_ids)
                 completion_ids.extend(completion_turn_ids)
                 completion_mask.extend(completion_turn_mask)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from typing import TYPE_CHECKING, Literal, Union, List, Dict
+from typing import TYPE_CHECKING, Literal, Union, List, Dict, Any
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
 import base64

--- a/verifiers/trainers/async_batch_generator.py
+++ b/verifiers/trainers/async_batch_generator.py
@@ -293,7 +293,7 @@ class AsyncBatchGenerator:
             mask_env_responses=request.mask_env_responses,
             mask_truncated_completions=request.mask_truncated_completions,
             zero_truncated_completions=request.zero_truncated_completions,
-        )          
+        )
 
         return BatchResult(
             batch_id=request.batch_id,

--- a/verifiers/trainers/async_batch_generator.py
+++ b/verifiers/trainers/async_batch_generator.py
@@ -4,7 +4,7 @@ import queue
 import threading
 import time
 from collections import deque
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -38,6 +38,7 @@ class BatchResult(BaseModel):
         default_factory=list
     )  # Store completions for logging
     prompts: list[Any] = Field(default_factory=list)  # Store prompts for logging
+    answers : list[Any]
 
 
 class AsyncBatchGenerator:
@@ -292,7 +293,7 @@ class AsyncBatchGenerator:
             mask_env_responses=request.mask_env_responses,
             mask_truncated_completions=request.mask_truncated_completions,
             zero_truncated_completions=request.zero_truncated_completions,
-        )
+        )          
 
         return BatchResult(
             batch_id=request.batch_id,
@@ -300,6 +301,7 @@ class AsyncBatchGenerator:
             all_reward_dict=all_reward_dict,
             completions=env_results.completion,
             prompts=env_results.prompt,
+            answers=request.env_inputs.answer
         )
 
     async def _evaluate_async(self, num_samples: int = -1) -> GenerateOutputs:

--- a/verifiers/trainers/async_batch_generator.py
+++ b/verifiers/trainers/async_batch_generator.py
@@ -301,7 +301,7 @@ class AsyncBatchGenerator:
             all_reward_dict=all_reward_dict,
             completions=env_results.completion,
             prompts=env_results.prompt,
-            answers=request.env_inputs.answer
+            answers=request.env_inputs.get("answer")
         )
 
     async def _evaluate_async(self, num_samples: int = -1) -> GenerateOutputs:

--- a/verifiers/trainers/async_batch_generator.py
+++ b/verifiers/trainers/async_batch_generator.py
@@ -4,7 +4,7 @@ import queue
 import threading
 import time
 from collections import deque
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -441,9 +441,8 @@ class GRPOTrainer(Trainer):
             )
             max_length = self.max_prompt_length  # Capture for closure
 
-            def filter_by_prompt_length(example, processing_class, max_length):
+            def filter_by_prompt_length(example, processing_class):
                 prompt = example["prompt"]
-                
                 if isinstance(prompt, list):
                     prompt_text = processing_class.apply_chat_template(
                         prompt, tokenize=False, add_generation_prompt=True
@@ -457,6 +456,7 @@ class GRPOTrainer(Trainer):
                     kwargs = {}
                     if "image" in example:
                         kwargs["images"] = [example["image"]]
+
                     inputs = processing_class(
                         text=prompt_text,
                         return_tensors="pt",

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -1047,14 +1047,21 @@ class GRPOTrainer(Trainer):
         for x in batch:
             prompt = x["prompt"]
             for message in prompt:
-                for content in message.get("content", []):
-                    if content.get("type") == "image" :
-                        img_url = pil_to_base64_url(x["image"])
-                        content.clear()
-                        content.update({
-                            "type": "image_url",
-                            "image_url": {"url":img_url}
-                        })
+                content = message.get("content", [])
+                if isinstance(content, list):
+                    for c in content:
+                        if isinstance(c, dict) and c.get("type") == "image":
+                            img_url = pil_to_base64_url(x["image"])
+                            c.clear()
+                            c.update({
+                                "type": "image_url",
+                                "image_url": {"url": img_url}
+                            })
+                elif isinstance(content, str):
+                    pass
+                else:
+                    print("Unknown content type:", type(content))
+    
             prompts.append(prompt)
     
         answers = [x["answer"] for x in batch]

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -1175,6 +1175,8 @@ class GRPOTrainer(Trainer):
             # Now retrieve the batch we need for this step
             if self.accelerator.is_main_process:
                 # Get batch result
+                
+                # TODO : toute le get vllm et préparation sert à arriver ici, est-ce que les grid et pixel values sont nécessaires ? je pense que oui pour la backward
                 batch_result = self.async_generator.get_batch(batch_id_to_retrieve)
                 processed_results = batch_result.processed_results
 

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -1234,7 +1234,7 @@ class GRPOTrainer(Trainer):
                         device=self.accelerator.device,
                     )
                 )
-                pixel_values_list.append(
+                pixel_values_list.append( # TODO : ici je pense qu'il faut gérer si on stack ensuite sur la première dimension ou pas
                     torch.tensor(
                         broadcast_data["pixel_values"][i],
                         device=self.accelerator.device,

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -13,11 +13,10 @@ import wandb
 from accelerate.utils import broadcast_object_list, gather_object, is_peft_model
 from peft import PeftConfig, get_peft_model
 from torch.utils.data import DataLoader, Sampler
-from transformers import AutoModelForCausalLM
 from transformers.integrations.deepspeed import is_deepspeed_zero3_enabled
 from transformers.modeling_utils import PreTrainedModel
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-from transformers import ProcessorMixin, AutoProcessor, AutoConfig
+from transformers import ProcessorMixin, AutoConfig
 from transformers.trainer import Trainer
 from transformers.trainer_callback import TrainerCallback
 from transformers.trainer_utils import seed_worker
@@ -790,25 +789,26 @@ class GRPOTrainer(Trainer):
         # Build model inputs - check if the model supports logits_to_keep (some models and VLMs don't)
         model_inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
 
-        # For Qwen models:
-        if image_grid_thw is not None and pixel_values is not None:
-            model_inputs["image_grid_thw"] = image_grid_thw
-        # For Gemma, SmolVLM2, LLaVa-Next etc.:
-        if pixel_values is not None:
-            model_inputs["pixel_values"] = pixel_values
-        # For SmolVLM2
-        if pixel_attention_mask is not None:
-            model_inputs["pixel_attention_mask"] = pixel_attention_mask
-        # For LLaVa-Next
-        if image_sizes is not None:
-            model_inputs["image_sizes"] = image_sizes
+        # TODO : check if needed or no
+        # # For Qwen models:
+        # if image_grid_thw is not None and pixel_values is not None:
+        #     model_inputs["image_grid_thw"] = image_grid_thw
+        # # For Gemma, SmolVLM2, LLaVa-Next etc.:
+        # if pixel_values is not None:
+        #     model_inputs["pixel_values"] = pixel_values
+        # # For SmolVLM2
+        # if pixel_attention_mask is not None:
+        #     model_inputs["pixel_attention_mask"] = pixel_attention_mask
+        # # For LLaVa-Next
+        # if image_sizes is not None:
+        #     model_inputs["image_sizes"] = image_sizes
 
-        # Only add logits_to_keep if the model supports it
-        if "logits_to_keep" in self.model_kwarg_keys:
-            # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
-            model_inputs["logits_to_keep"] = logits_to_keep + 1
+        # # Only add logits_to_keep if the model supports it
+        # if "logits_to_keep" in self.model_kwarg_keys:
+        #     # We add 1 to `logits_to_keep` because the last logits of the sequence is later excluded
+        #     model_inputs["logits_to_keep"] = logits_to_keep + 1
 
-        model_inputs["use_cache"] = False  # only used in generation; set False to suppress warnings
+        # model_inputs["use_cache"] = False  # only used in generation; set False to suppress warnings
 
         last_hidden_state = unwrapped_model.model(**model_inputs).last_hidden_state
         # Exclude the last value: it corresponds to the next token pred

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -825,7 +825,6 @@ class GRPOTrainer(Trainer):
         attention_mask,
         logits_to_keep,
         batch_size=None,
-        compute_entropy=False,
         pixel_values=None,
         image_grid_thw=None,
     ) -> torch.Tensor:
@@ -1349,9 +1348,8 @@ class GRPOTrainer(Trainer):
             input_ids,
             attention_mask,
             logits_to_keep,
-            compute_entropy=self.top_entropy_quantile < 1.0,
-            pixel_values=inputs.pixel_values,
-            image_grid_thw=inputs.image_grid_thw,
+            pixel_values=inputs.get("pixel_values"),
+            image_grid_thw=inputs.get("image_grid_thw"),
         )
         # Compute the loss
         advantages = inputs["advantages"]
@@ -1379,12 +1377,12 @@ class GRPOTrainer(Trainer):
             with torch.no_grad():
                 if self.ref_model is not None:
                     ref_per_token_logps = self._get_per_token_logps(
-                        self.ref_model, input_ids, attention_mask, logits_to_keep, pixel_values=inputs.pixel_values,image_grid_thw=inputs.image_grid_thw,
+                        self.ref_model, input_ids, attention_mask, logits_to_keep, pixel_values=inputs.get("pixel_values"),image_grid_thw=inputs.get("image_grid_thw"),
                     )
                 else:
                     with self.accelerator.unwrap_model(self.model).disable_adapter():  # type: ignore
                         ref_per_token_logps = self._get_per_token_logps(
-                            self.model, input_ids, attention_mask, logits_to_keep, pixel_values=inputs.pixel_values,image_grid_thw=inputs.image_grid_thw,
+                            self.model, input_ids, attention_mask, logits_to_keep, pixel_values=inputs.get("pixel_values"),image_grid_thw=inputs.get("image_grid_thw"),
                         )
             per_token_kl = (
                 torch.exp(ref_per_token_logps - per_token_logps)

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -398,6 +398,8 @@ class GRPOTrainer(Trainer):
 
         eval_dataset = env.get_eval_dataset()
 
+        print("data", train_dataset)
+        print(train_dataset.column_names)
         if "prompt" not in train_dataset.column_names:
             raise ValueError("Train dataset must contain a 'prompt' column")
         if "answer" not in train_dataset.column_names:

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -846,7 +846,7 @@ class GRPOTrainer(Trainer):
             # Build model inputs - check if the model supports logits_to_keep (some models and VLMs don't)
             model_inputs = {"input_ids": input_ids_batch, "attention_mask": attention_mask_batch}
             
-            
+            print("_get_per_token_logps",pixel_values.shape)
             # TODO : check if needed there or if already robust to VLM
             if image_grid_thw is not None and pixel_values is not None:
                 model_inputs["image_grid_thw"] = image_grid_thw[i : i + batch_size]

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -213,37 +213,6 @@ def shuffle_tensor_dict(
         key: tensor[permutation] if tensor is not None else None
         for key, tensor in tensor_dict.items()
     }
-
-def split_pixel_values_by_grid(batch: dict[str, torch.Tensor]) -> dict[str, Union[torch.Tensor, list[torch.Tensor]]]:
-    """
-    Splits `batch["pixel_values"]` into a list of tensors based on the product of each row in
-    `batch["image_grid_thw"]`, while keeping other entries unchanged.
-    """
-    if "image_grid_thw" not in batch or "pixel_values" not in batch:
-        return batch
-
-    lengths = batch["image_grid_thw"].prod(dim=1).tolist()  # [batch_size]
-    pixel_values = batch["pixel_values"]  # [total, feature_dim]
-
-    if sum(lengths) != pixel_values.size(0):
-        raise ValueError(f"Mismatch: sum(lengths) = {sum(lengths)} != pixel_values.size(0) = {pixel_values.size(0)}")
-
-    split_values = list(torch.split(batch["pixel_values"], lengths, dim=0))
-    return {**batch, "pixel_values": split_values}
-
-
-def unsplit_pixel_values_by_grid(batch: dict[str, Union[torch.Tensor, list[torch.Tensor]]]) -> dict[str, torch.Tensor]:
-    """
-    Opposite of `split_pixel_values_by_grid`. Merges a list of tensors in `batch["pixel_values"]`
-    back into a single tensor along the first dimension.
-    """
-    pixel_values = batch.pixel_values
-
-    if isinstance(pixel_values, list):
-        merged = torch.cat(pixel_values, dim=0)
-        return {**batch, "pixel_values": merged}
-    else:
-        return batch
     
 def nanmin(tensor: torch.Tensor) -> torch.Tensor:
     """

--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -4,7 +4,7 @@ import logging
 import time
 from collections import defaultdict, deque
 from contextlib import nullcontext
-from typing import Any, Dict, List, Optional, Sized, Tuple, Union
+from typing import Any, Dict, List, Optional, Sized, Union
 
 import datasets
 import numpy as np
@@ -838,14 +838,16 @@ class GRPOTrainer(Trainer):
             attention_mask_batch = attention_mask[i : i + batch_size]
             # Build model inputs - check if the model supports logits_to_keep (some models and VLMs don't)
             model_inputs = {"input_ids": input_ids_batch, "attention_mask": attention_mask_batch}
-
-            if image_grid_thw is not None and pixel_values is not None:
-                model_inputs["image_grid_thw"] = image_grid_thw[start : start + batch_size]
-                start_pixel_idx = image_grid_thw[:start].prod(-1).sum().item()
-                end_pixel_idx = image_grid_thw[: start + batch_size].prod(-1).sum().item()
-                model_inputs["pixel_values"] = pixel_values[start_pixel_idx:end_pixel_idx]
-            elif pixel_values is not None:
-                model_inputs["pixel_values"] = pixel_values[start : start + batch_size]
+            
+            
+            # TODO : check if needed there or if already robust to VLM
+            # if image_grid_thw is not None and pixel_values is not None:
+            #     model_inputs["image_grid_thw"] = image_grid_thw[start : start + batch_size]
+            #     start_pixel_idx = image_grid_thw[:start].prod(-1).sum().item()
+            #     end_pixel_idx = image_grid_thw[: start + batch_size].prod(-1).sum().item()
+            #     model_inputs["pixel_values"] = pixel_values[start_pixel_idx:end_pixel_idx]
+            # elif pixel_values is not None:
+            #     model_inputs["pixel_values"] = pixel_values[start : start + batch_size]
 
             # Only add logits_to_keep if the model supports it
             if "logits_to_keep" in self.model_kwarg_keys:

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -89,8 +89,8 @@ class ProcessedOutputs(BaseModel):
 
     prompt_ids: list[list[int]]
     prompt_mask: list[list[int]]
-    image_grid_thw: Optional[list[list[int]]] = None
-    pixel_values: Optional[list[list[list[float]]]] = None
+    image_grid_thw: Optional[list[Optional[list[int]]]] = None
+    pixel_values: Optional[list[Optional[list[list[float]]]]] = None
     completion_ids: list[list[int]]
     completion_mask: list[list[int]]
     completion_logprobs: list[list[float]]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -89,7 +89,7 @@ class ProcessedOutputs(BaseModel):
     prompt_ids: list[list[int]]
     prompt_mask: list[list[int]]
     image_grid: list[list[int]]
-    pixel_values: list[list[int]]
+    pixel_values: list[list[float]]
     completion_ids: list[list[int]]
     completion_mask: list[list[int]]
     completion_logprobs: list[list[float]]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -88,6 +88,8 @@ class ProcessedOutputs(BaseModel):
 
     prompt_ids: list[list[int]]
     prompt_mask: list[list[int]]
+    image_grid: list[list[int]]
+    pixel_values: list[list[int]]
     completion_ids: list[list[int]]
     completion_mask: list[list[int]]
     completion_logprobs: list[list[float]]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -88,8 +88,8 @@ class ProcessedOutputs(BaseModel):
 
     prompt_ids: list[list[int]]
     prompt_mask: list[list[int]]
-    image_grid: list[list[int]]
-    pixel_values: list[list[int]]
+    image_grid_thw: list[list[int]]
+    pixel_values: list[list[float]]
     completion_ids: list[list[int]]
     completion_mask: list[list[int]]
     completion_logprobs: list[list[float]]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -5,6 +5,7 @@ from typing import (
     Awaitable,
     Callable,
     Literal,
+    Optional
 )
 
 from openai.types.chat.chat_completion import ChatCompletion
@@ -88,8 +89,8 @@ class ProcessedOutputs(BaseModel):
 
     prompt_ids: list[list[int]]
     prompt_mask: list[list[int]]
-    image_grid_thw: list[list[int]]
-    pixel_values: list[list[float]]
+    image_grid_thw: Optional[list[list[int]]] = None
+    pixel_values: Optional[list[list[list[float]]]] = None
     completion_ids: list[list[int]]
     completion_mask: list[list[int]]
     completion_logprobs: list[list[float]]


### PR DESCRIPTION
## Description
This Pull Request introduces support for Vision-Language Models (VLMs) into the environments and the GRPO trainer. This functionality is implemented by tracking pixel values and image grids as the base inputs, and then transforming images into Base64 format to comply with VLLM/OpenAI chat formats. The implementation is adapted to work with both standard text tokenizers and multimodal/mixin processors. It also adds Image and Answer login in wanDB table to simplify data analysis during training.

The motivation for adding VLM support is strategic: we believe Vision-Language environments are critical for advancing AGI and Reinforcement Learning (RL) research. This feature was necessary to begin testing several promising, high-value environments.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `uv run pytest`

It was end to end tested with 3 Prime-RL envs :

OCR VL with Qwen VL 2.5 3B and 7B : https://app.primeintellect.ai/dashboard/environments/ulrick-bl/ocr-vl (single turn image)

Rebus VL Thinking with Qwen VL 2.5 7B : https://app.primeintellect.ai/dashboard/environments/ulrick-bl/rebus-vl-thinking (single turn image)

Semantix with Qwen 2.5 0.5B : https://app.primeintellect.ai/dashboard/environments/ulrick-bl/semantic (multi turn text)



### Test Coverage
- Current coverage: 33%
- Coverage after changes: 29%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
